### PR TITLE
Add **/setupTests.js to import/no-extraneous-dependencies matchers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Airbnb JavaScript Style Guide() {
 
+**See [Amendments Section](#amendments) for our changes**
+
 *A mostly reasonable approach to JavaScript*
 
 > **Note**: this guide assumes you are using [Babel](https://babeljs.io), and requires that you use [babel-preset-airbnb](https://npmjs.com/babel-preset-airbnb) or the equivalent. It also assumes you are installing shims/polyfills in your app, with [airbnb-browser-shims](https://npmjs.com/airbnb-browser-shims) or the equivalent.
@@ -3690,5 +3692,6 @@ We encourage you to fork this guide and change the rules to fit your team’s st
 - Prevent this from being used in stateless functional components
 - AirBnb prefers to enforce only `.jsx` file extension files may contain JSX. We prefer all our files to allow JSX.
 - Validate JSX has key prop when in array or iterator
+- We added `**/setupTests.js` to our list of `import/no-extraneous-dependencies` matchers.
 
 # };

--- a/linters/eslintrc.json
+++ b/linters/eslintrc.json
@@ -85,7 +85,8 @@
           "**/gulpfile.*.js",
           "**/Gruntfile{,.js}",
           "**/protractor.conf.js",
-          "**/protractor.conf.*.js"
+          "**/protractor.conf.*.js",
+          "**/setupTests.js"
         ],
         "optionalDependencies": false
       }

--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -87,6 +87,7 @@ module.exports = {
         '**/Gruntfile{,.js}', // grunt config
         '**/protractor.conf.js', // protractor config
         '**/protractor.conf.*.js', // protractor config
+        '**/setupTests.js', // test setup file
       ],
       optionalDependencies: false,
     }],


### PR DESCRIPTION
# Context

```
yarn lint
yarn run v1.7.0
$ eslint src express

~/partner_websites/src/setupTests.js
  2:1  error  'enzyme-adapter-react-16' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
  3:1  error  'enzyme' should be listed in the project's dependencies, not devDependencies                   import/no-extraneous-dependencies

✖ 2 problems (2 errors, 0 warnings)
```

# Changes

- Add `**/setupTests.js` to `import/no-extraneous-dependencies` matchers list.